### PR TITLE
prevent google from indexing the widgets contents

### DIFF
--- a/src/Widget.svelte
+++ b/src/Widget.svelte
@@ -35,6 +35,8 @@
 
 <style src="Widget.scss"></style>
 
+{@html `<!--googleoff: all-->`}
+
 {#if $config}
     <details open={open}>
         <summary on:click|preventDefault={toggleOpen}>
@@ -171,3 +173,5 @@
 {/if}
 
 {@html ICON_DEFS}
+
+{@html `<!--googleon: all-->`}


### PR DESCRIPTION
wraps widget content in `<!--googleoff: all-->` and `<!--googleon: all-->` tags.
Docs here: https://support.google.com/gsa/answer/6329153#82542